### PR TITLE
Update `Accept` HTTP header for XML repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These are two identical files stored *twice* on the mobile's file storage, and t
 
 These headers should be included with every request:
 
-    "Accept": "application/xml"
+    "Accept": "text/xml; charset=UTF-8"
     "X-Client-Name": "AlphaWallet"
     "X-Client-Version": "1.0.3"
     "X-Platform-Name": "iOS"


### PR DESCRIPTION
The repo server currently accepts "text/xml; charset=UTF-8" instead of "application/xml". The former looks better any way according to [RFC 3023](http://www.rfc-editor.org/rfc/rfc3023.txt)

> If an XML document -- that is, the unprocessed, source XML document
>    -- is readable by casual users, text/xml is preferable to
>    application/xml.  MIME user agents (and web user agents) that do not
>    have explicit support for text/xml will treat it as text/plain

This PR updates the doc.